### PR TITLE
Remove TodoView.model

### DIFF
--- a/js/todo-app.js
+++ b/js/todo-app.js
@@ -168,11 +168,6 @@ class TodoView extends View {
     // *... is a list tag.*
     this.tagName = 'li';
 
-    // *The TodoView listens for changes to its model, re-rendering. Since there's
-    // a one-to-one correspondence between a **Todo** and a **TodoView** in this
-    // app, we set a direct reference on the model for convenience.*
-    this.model = Todo;
-
     // *Cache the template function for a single item.*
     this.template = _.template($('#item-template').html());
 


### PR DESCRIPTION
There's no point making a reference to the model class from the view. It will be overwritten anyway because `this.model` refers to the model instance, which always exists before the view.

The reason `todoList.model` points to the model class is so that you can do todoList.add([data1, data2]) and it knows which model to instantiate.
